### PR TITLE
Initial Kubeapps support closes #75

### DIFF
--- a/REDACTED-params.yaml
+++ b/REDACTED-params.yaml
@@ -66,6 +66,6 @@ concourse:
   namespace: concourse
   fqdn: concourse.dorn.tkg-aws-e2-lab.winterfell.live
   tmc-workspace: concourse-workspace
-argocd:
-  server-fqdn: argocd.dorn.tkg-aws-e2-lab.winterfell.live
-  password: REDACTED
+kubeapps:
+  fqdn: kubeapps.dorn.tkg-aws-e2-lab.winterfell.live
+

--- a/docs/bonus-labs/kubeapps.md
+++ b/docs/bonus-labs/kubeapps.md
@@ -66,4 +66,4 @@ open https://$(yq r $PARAMS_YAML kubeapps.fqdn)
 
 ### Users
 
-TBD
+Coming Soon....

--- a/docs/bonus-labs/kubeapps.md
+++ b/docs/bonus-labs/kubeapps.md
@@ -1,0 +1,69 @@
+# Install Kubeapps
+
+### Set environment variables
+The following section should be added to or exist in your local params.yaml file:
+
+```bash
+kubeapps:
+  fqdn: kubeapps.<shared-cluster domain name>
+```
+
+### Change to Shared Services Cluster
+Kubeapps should be installed in the shared services cluster, as it is going to be available to all users.  We need to ensure we are in the correct context before proceeding.
+
+```bash
+CLUSTER_NAME=$(yq r $PARAMS_YAML shared-services-cluster.name)
+kubectl config use-context $CLUSTER_NAME-admin@$CLUSTER_NAME
+```
+
+### Prepare Manifests
+Prepare the YAML manifests for the related kubeapps K8S objects.  Manifest will be output into `kubeapps/generated/` in case you want to inspect.
+```bash
+./kubeapps/00-generate_yaml.sh $(yq r $PARAMS_YAML shared-services-cluster.name)
+```
+
+### Create Kubeapps namespace
+Create the kubeapps namespace.
+```bash
+kubectl apply -f generated/$CLUSTER_NAME/kubeapps/01-namespace.yaml
+```
+
+### Add helm repo and install kubeapps
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install kubeapps --namespace kubeapps bitnami/kubeapps -f generated/$CLUSTER_NAME/kubeapps/kubeapps-values.yaml
+```
+
+## Validation Step
+1. All kubeapps pods are in a running state:
+```bash
+kubectl get po -n kubeapps
+```
+2. Certificate is True and Ingress created:
+```bash
+kubectl get cert,ing -n kubeapps
+```
+1. Open a browser and navigate to https://<$KUBEAPPS_FQDN>.  
+```bash
+open https://$(yq r $PARAMS_YAML kubeapps.fqdn)
+```
+
+## Okta Integration
+
+### Admin 
+
+1. Log into your Okta account you created as part of the [Okta Setup Lab](../mgmt-cluster/04_okta_mgmt.md).  The URL should be in your `params.yaml` file under okta.auth-server-fqdn.
+
+2. Choose Directory (top menu) > Click Add Group > Enter: kubeapps-operator > Click Add Group.
+
+3. Click on the kubeapps-operator group > Click Manage People > Click the Names of anyone you want with too have Admin status in Kubeapps > Click Save
+
+4. Add kubeapps-operator to ClusterRoleBinding for cluster.admin (This isn't a best practice, but is easiest for a demo).
+   Run:
+```bash
+./scripts/tmc-policy.sh $(yq r $PARAMS_YAML shared-services-cluster.name) cluster.admin kubeapps-operator
+```
+
+### Users
+
+TBD

--- a/kubeapps/00-generate_yaml.sh
+++ b/kubeapps/00-generate_yaml.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+if [ ! $# -eq 1 ]; then
+  echo "Must supply cluster_name as args"
+  exit 1
+fi
+
+CLUSTER_NAME=$1
+
+DEX_FQDN=$(yq r $PARAMS_YAML management-cluster.dex-fqdn)
+KUBEAPPS_FQDN=$(yq r $PARAMS_YAML kubeapps.fqdn)
+
+mkdir -p generated/$CLUSTER_NAME/kubeapps
+
+# 01-namespace.yaml
+yq read kubeapps/01-namespace.yaml > generated/$CLUSTER_NAME/kubeapps/01-namespace.yaml
+
+# kubeapps-values.yaml
+yq read kubeapps/kubeapps-values.yaml > generated/$CLUSTER_NAME/kubeapps/kubeapps-values.yaml
+yq write generated/$CLUSTER_NAME/kubeapps/kubeapps-values.yaml -i "ingress.hostname" "$KUBEAPPS_FQDN"
+yq write generated/$CLUSTER_NAME/kubeapps/kubeapps-values.yaml -i "authProxy.additionalFlags"[+]  " -oidc-issuer-url=$DEX_FQDN" 
+yq write generated/$CLUSTER_NAME/kubeapps/kubeapps-values.yaml -i "authProxy.additionalFlags"[+]  " -scope=openid email groups"

--- a/kubeapps/01-namespace.yaml
+++ b/kubeapps/01-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubeapps

--- a/kubeapps/kubeapps-values.yaml
+++ b/kubeapps/kubeapps-values.yaml
@@ -1,0 +1,34 @@
+
+useHelm3: true
+allowNamespaceDiscovery: true
+ingress:
+  enabled: true
+  certManager: true
+  hostname: 
+  tls: true
+  annotations:
+    ingress.kubernetes.io/ssl-redirect: "true"
+    ingress.kubernetes.io/proxy-body-size: "0"
+    kubernetes.io/ingress.class: "contour"
+    cert-manager.io/cluster-issuer: "letsencrypt-contour-cluster-issuer"
+    kubernetes.io/tls-acme: "true"
+
+# Auth Proxy for OIDC support
+# ref: https://github.com/kubeapps/kubeapps/blob/master/docs/user/using-an-OIDC-provider.md
+authProxy:
+   enabled: true
+   provider: oidc
+   clientID: svcs
+   clientSecret: FOO_SECRET
+   cookieSecret: FOO_SECRET_FOO_FOO
+   #oauthLoginURI: /oauth2/start
+   #oauthLogoutURI: /oauth2/sign_out
+   additionalFlags:
+   
+   
+   # - -oidc-issuer-url=$DEX_FQDN
+   # - -scope=openid email groups
+
+
+
+


### PR DESCRIPTION
Initial kubeapps support with Okta Integration.  Docs only include kubeapps-operator, but I will be adding the kubeapps-users group soon.  For now, you can just use operator for demos.