### PR TITLE
Fix broken link

### DIFF
--- a/helm-install/management-cluster-setup/02-create-mgmt-cluster/00-prerequisities.md
+++ b/helm-install/management-cluster-setup/02-create-mgmt-cluster/00-prerequisities.md
@@ -1,6 +1,6 @@
 Make sure you are connected to VMware VPN.
 
- - ###### Configure OIDC - [Setup](/management-cluster-setup/01-oidc-setup/oid_setup.md)
+ - ###### Configure OIDC - [Setup](../management-cluster-setup/01-oidc-setup/oid_setup.md)
 
     Once you have the `Client ID` and `Client Secret`, encode them to BASE64 in your terminal and save those values
 

--- a/helm-install/management-cluster-setup/02-create-mgmt-cluster/00-prerequisities.md
+++ b/helm-install/management-cluster-setup/02-create-mgmt-cluster/00-prerequisities.md
@@ -1,6 +1,6 @@
 Make sure you are connected to VMware VPN.
 
- - ###### Configure OIDC - [Setup](../management-cluster-setup/01-oidc-setup/oid_setup.md)
+ - ###### Configure OIDC - [Setup](../../management-cluster-setup/01-oidc-setup/oid_setup.md)
 
     Once you have the `Client ID` and `Client Secret`, encode them to BASE64 in your terminal and save those values
 


### PR DESCRIPTION
link to "/management-cluster-setup/01-oidc-setup/oid_setup.md" is broken as this link does not accurately reflect the directory structure. Prepended link with "../.." to align with directory structure and verified this results in the correct resolution per my fork here: https://github.com/afewell/tkg-lab/blob/patch-1/helm-install/management-cluster-setup/02-create-mgmt-cluster/00-prerequisities.md

Thanks! 